### PR TITLE
Add audit timestamps to ContentRecordModel and corresponding SQL migration

### DIFF
--- a/src/main/java/br/com/aguideptbr/features/content/ContentRecordModel.java
+++ b/src/main/java/br/com/aguideptbr/features/content/ContentRecordModel.java
@@ -3,6 +3,7 @@ package br.com.aguideptbr.features.content;
 import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
 import jakarta.persistence.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
@@ -79,6 +80,44 @@ public class ContentRecordModel extends PanacheEntityBase {
 
     @Column(name = "default_audio_language", length = 10)
     public String defaultAudioLanguage;
+
+    // ========== AUDITORIA - DATA E HORA DE CRIAÇÃO E ATUALIZAÇÃO ==========
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime updatedAt;
+
+    /**
+     * Automatically sets the creation timestamp before persisting the entity.
+     * This method is called by JPA before the entity is inserted into the database.
+     */
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * Automatically updates the modification timestamp before updating the entity.
+     * This method is called by JPA before the entity is updated in the database.
+     */
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // ========== GETTERS E SETTERS PARA AUDITORIA ==========
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
 
     // ========== MÉTODOS DE BUSCA ==========
 

--- a/src/main/java/br/com/aguideptbr/features/content/ContentRecordModel.java
+++ b/src/main/java/br/com/aguideptbr/features/content/ContentRecordModel.java
@@ -81,7 +81,7 @@ public class ContentRecordModel extends PanacheEntityBase {
     @Column(name = "default_audio_language", length = 10)
     public String defaultAudioLanguage;
 
-    // ========== AUDITORIA - DATA E HORA DE CRIAÇÃO E ATUALIZAÇÃO ==========
+    // ========== AUDITORIA - DATA E HORA DE CRIAÇÃO E ATUALIZAÇÃO ============
     @Column(name = "created_at", nullable = false, updatable = false)
     @Temporal(TemporalType.TIMESTAMP)
     private LocalDateTime createdAt;

--- a/src/main/resources/db/migration/V1.0.2__Add_audit_timestamps.sql
+++ b/src/main/resources/db/migration/V1.0.2__Add_audit_timestamps.sql
@@ -1,0 +1,20 @@
+-- ========================================
+-- ADD AUDIT TIMESTAMPS TO CONTENT_RECORD
+-- Versão: 1.0.2
+-- Data: 2025-10-09
+-- ========================================
+
+-- Adiciona colunas de auditoria para rastrear criação e atualização
+ALTER TABLE content_record
+ADD COLUMN created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- Cria índice para consultas ordenadas por data de criação
+CREATE INDEX idx_content_record_created_at ON content_record(created_at DESC);
+
+-- Cria índice para consultas ordenadas por data de atualização
+CREATE INDEX idx_content_record_updated_at ON content_record(updated_at DESC);
+
+-- Comentários para documentação
+COMMENT ON COLUMN content_record.created_at IS 'Data e hora de criação do registro';
+COMMENT ON COLUMN content_record.updated_at IS 'Data e hora da última atualização do registro';

--- a/src/main/resources/db/migration/V1.0.2__Add_audit_timestamps.sql
+++ b/src/main/resources/db/migration/V1.0.2__Add_audit_timestamps.sql
@@ -2,7 +2,7 @@
 -- ADD AUDIT TIMESTAMPS TO CONTENT_RECORD
 -- Versão: 1.0.2
 -- Data: 2025-10-09
--- ========================================
+-- ==========================================
 
 -- Adiciona colunas de auditoria para rastrear criação e atualização
 ALTER TABLE content_record


### PR DESCRIPTION
- Automatically sets the creation timestamp before persisting the entity.
- Automatically updates the modification timestamp before updating the entity.