### PR TITLE
docs: add JavaDoc documentation to Content REST API

### DIFF
--- a/src/main/java/br/com/aguideptbr/features/content/ContentRecordResource.java
+++ b/src/main/java/br/com/aguideptbr/features/content/ContentRecordResource.java
@@ -22,6 +22,16 @@ import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
+/**
+ * REST Controller para gerenciamento de conteúdos (vídeos, artigos, podcasts).
+ *
+ * Esta classe implementa endpoints REST para operações CRUD completas
+ * e busca paginada de conteúdos educacionais.
+ *
+ * @author Cleidson Machado
+ * @since 1.0
+ * @see ContentService
+ */
 @Path("/contents")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
@@ -45,7 +55,18 @@ public class ContentRecordResource {
     // with pagination
     // **
 
-    // ✅ Paginated list if page/size is specified, otherwise returns the last 50...
+    /**
+     * Lista conteúdos com suporte a paginação e ordenação.
+     *
+     * Se page/size forem especificados, retorna resposta paginada completa.
+     * Caso contrário, retorna os últimos 50 itens para melhor performance.
+     *
+     * @param page      Número da página (opcional, inicia em 0)
+     * @param size      Tamanho da página (opcional, recomendado 10-50)
+     * @param sortField Campo para ordenação (padrão: title)
+     * @param sortOrder Direção da ordenação: asc ou desc (padrão: asc)
+     * @return Response com lista de conteúdos ou mensagem de erro
+     */
     @GET
     public Response listContents(
             @QueryParam("page") Integer page,

--- a/src/main/java/br/com/aguideptbr/features/content/ContentService.java
+++ b/src/main/java/br/com/aguideptbr/features/content/ContentService.java
@@ -8,11 +8,32 @@ import br.com.aguideptbr.util.PaginatedResponse;
 import io.quarkus.panache.common.Sort;
 import jakarta.enterprise.context.ApplicationScoped;
 
+/**
+ * Serviço de negócio para gerenciamento de conteúdos.
+ *
+ * Responsável por implementar a lógica de negócio relacionada aos conteúdos,
+ * incluindo paginação, ordenação e validações.
+ *
+ * @author Cleidson Machado
+ * @since 1.0
+ */
 @ApplicationScoped
 public class ContentService {
 
+    /** Limite padrão de itens retornados quando paginação não é especificada */
     private static final int DEFAULT_LIMIT = 50;
 
+    /**
+     * Retorna conteúdos paginados com ordenação customizada.
+     *
+     * @param page      Número da página (zero-based)
+     * @param size      Quantidade de itens por página
+     * @param sortField Campo para ordenação (title, channelName, publishedAt, etc)
+     * @param sortOrder Direção da ordenação (asc ou desc)
+     * @return PaginatedResponse contendo lista de conteúdos e metadados de
+     *         paginação
+     * @throws IllegalArgumentException se o sortField for inválido
+     */
     public PaginatedResponse<ContentRecordModel> getPaginatedContents(int page, int size, String sortField,
             String sortOrder) {
         validateSortField(sortField);
@@ -29,6 +50,17 @@ public class ContentService {
                 page);
     }
 
+    /**
+     * Retorna lista limitada de conteúdos (máximo 50 itens).
+     *
+     * Utilizado quando paginação não é especificada na requisição,
+     * evitando sobrecarga ao retornar muitos registros.
+     *
+     * @param sortField Campo para ordenação
+     * @param sortOrder Direção da ordenação (asc ou desc)
+     * @return Map contendo mensagem informativa e lista limitada de itens
+     * @throws IllegalArgumentException se o sortField for inválido
+     */
     public Map<String, Object> getLimitedContents(String sortField, String sortOrder) {
         validateSortField(sortField);
         Sort sortBy = buildSort(sortField, sortOrder);


### PR DESCRIPTION
## 📝 Descrição

Esta PR adiciona documentação JavaDoc completa para as classes de gerenciamento de conteúdos.

### ✨ Alterações
- ✅ JavaDoc na classe `ContentRecordResource`
- ✅ JavaDoc na classe `ContentService`
- ✅ Documentação dos métodos de listagem e paginação
- ✅ Comentários explicativos sobre parâmetros e retornos

### 🎯 Objetivo
Melhorar a documentação do código para facilitar manutenção e onboarding de novos desenvolvedores.

### 🧪 Tipo de Mudança
- [x] Documentação
- [ ] Nova Feature
- [ ] Bug Fix
- [ ] Refatoração

### 🔍 Checklist
- [x] Apenas comentários (sem alteração de lógica)
- [x] Commits seguem padrão Conventional Commits
- [x] PR criada para teste de webhook Jenkins