### PR TITLE
fix(security): adiciona mp.jwt.sign.key-content opcional para resolve…

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,6 +59,10 @@ quarkus.http.cors.headers=accept,authorization,content-type,x-requested-with
 mp.jwt.verify.publickey.location=security/jwt-public.pem
 mp.jwt.sign.key.location=security/jwt-private.pem
 
+# WORKAROUND: Quarkus exige mp.jwt.sign.key-content mesmo quando usando .location
+# Se a variável de ambiente não existir, usa valor opcional vazio
+mp.jwt.sign.key-content=${JWT_SIGN_KEY_CONTENT:}
+
 # Issuer do token (identificador único da API)
 mp.jwt.verify.issuer=https://aguide.com.br
 smallrye.jwt.sign.issuer=https://aguide.com.br


### PR DESCRIPTION
…r erro de config

- Adiciona mp.jwt.sign.key-content=${JWT_SIGN_KEY_CONTENT:} (opcional)
- Resolve erro 'Failed to load config value for mp.jwt.sign.key-content'
- Mantém mp.jwt.sign.key.location como prioridade
- Produção pode usar variável de ambiente JWT_SIGN_KEY_CONTENT se necessário
- Fallback para valor vazio quando não definida