### PR TITLE
feat: Implement content ownership validation feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,16 @@ QUARKUS_HTTPS_PORT=8443
 # ========== LOGS ==========
 # DEBUG = desenvolvimento | INFO = produção
 QUARKUS_LOG_LEVEL=DEBUG
+
+# ========== OWNERSHIP VALIDATION ==========
+# 🔒 SEGURANÇA: Chave secreta para HMAC-SHA256 de validação de propriedade
+# IMPORTANTE: Use uma chave forte de pelo menos 32 caracteres
+# Pode ser gerada com: openssl rand -hex 32
+# DEV: Pode usar chave simples
+# PROD: OBRIGATÓRIO usar chave criptograficamente segura
+OWNERSHIP_VALIDATION_SECRET=your-secret-key-for-ownership-validation-minimum-32-chars
+
+# ========== SSL KEYSTORE (DEV ONLY) ==========
+# Senha do keystore SSL para desenvolvimento local
+# Produção usa NGINX para SSL (não precisa disso)
+KEYSTORE_PASSWORD=your_keystore_password_here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
       DB_PROD_USERNAME: quarkus
       DB_PROD_PASSWORD: quarkus123
 
+      # 🔒 SEGURANÇA: Chave secreta para validação de propriedade
+      OWNERSHIP_VALIDATION_SECRET: b8e75a1106e8e13740ea7082f31ef5d550f8787e2eafad2b9fbb5d23c2771c41
+
+      # 🔐 SSL KEYSTORE (se necessário em produção)
+      KEYSTORE_PASSWORD: quarkus
+
       # ⚠️ CRÍTICO: SEMPRE usar profile 'prod' no VPS!
       # prod = Não limpa banco, usa quarkus_db
       # NUNCA usar 'dev' em produção (causaria perda de dados)

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# ========================================
+# Script de Configuração do .env
+# ========================================
+# Gera chaves seguras e atualiza o arquivo .env
+# Uso: ./setup-env.sh
+
+set -e  # Exit on error
+
+CYAN='\033[0;36m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+NC='\033[0m' # No Color
+
+echo -e "${CYAN}"
+echo "========================================="
+echo "  Configuração de Variáveis de Ambiente"
+echo "========================================="
+echo -e "${NC}"
+
+# Verificar se .env já existe
+if [ -f ".env" ]; then
+    echo -e "${YELLOW}⚠️  Arquivo .env já existe!${NC}"
+    read -p "Deseja sobrescrever? (s/N): " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Ss]$ ]]; then
+        echo -e "${RED}❌ Operação cancelada${NC}"
+        exit 1
+    fi
+fi
+
+# Copiar template
+echo -e "${CYAN}📋 Copiando .env.example para .env...${NC}"
+cp .env.example .env
+
+# Gerar chave HMAC segura
+echo -e "${CYAN}🔐 Gerando chave HMAC-SHA256 segura...${NC}"
+HMAC_SECRET=$(openssl rand -hex 32)
+
+if [ -z "$HMAC_SECRET" ]; then
+    echo -e "${RED}❌ Erro ao gerar chave HMAC!${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ Chave gerada: ${HMAC_SECRET:0:16}...${NC}"
+
+# Atualizar .env com a chave gerada
+echo -e "${CYAN}📝 Atualizando .env com chave HMAC...${NC}"
+
+# macOS usa sed diferente do Linux
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    # macOS
+    sed -i '' "s/your-secret-key-for-ownership-validation-minimum-32-chars/$HMAC_SECRET/" .env
+    sed -i '' "s/your_keystore_password_here/quarkus/" .env
+else
+    # Linux
+    sed -i "s/your-secret-key-for-ownership-validation-minimum-32-chars/$HMAC_SECRET/" .env
+    sed -i "s/your_keystore_password_here/quarkus/" .env
+fi
+
+# Configurar permissões (somente owner pode ler/escrever)
+chmod 600 .env
+
+echo -e "${GREEN}✅ Arquivo .env configurado com sucesso!${NC}"
+echo ""
+echo -e "${YELLOW}📋 Próximos passos:${NC}"
+echo "1. Edite o arquivo .env e configure suas credenciais de banco:"
+echo "   - DB_DEV_NAME, DB_DEV_USERNAME, DB_DEV_PASSWORD"
+echo "   - DB_TEST_NAME, DB_TEST_USERNAME, DB_TEST_PASSWORD"
+echo ""
+echo "2. Carregue as variáveis de ambiente:"
+echo -e "   ${CYAN}source .env${NC}"
+echo ""
+echo "3. Inicie a aplicação:"
+echo -e "   ${CYAN}./mvnw quarkus:dev${NC}"
+echo ""
+echo -e "${GREEN}🔒 Segurança: O arquivo .env está protegido (permissão 600)${NC}"
+echo -e "${GREEN}⚠️  NUNCA commite o arquivo .env no Git!${NC}"

--- a/src/main/java/br/com/aguideptbr/features/content/ContentRecordModel.java
+++ b/src/main/java/br/com/aguideptbr/features/content/ContentRecordModel.java
@@ -102,6 +102,18 @@ public class ContentRecordModel extends PanacheEntityBase {
     @Column(name = "default_audio_language", length = 10)
     public String defaultAudioLanguage;
 
+    // ========== VALIDAÇÃO DE PROPRIEDADE ==========
+    /**
+     * HMAC-SHA256 hash de validação de propriedade.
+     * NULL = sem propriedade validada
+     * != NULL = propriedade reconhecida
+     *
+     * Este campo evita requests extras do Flutter para verificar ownership.
+     * Ao carregar lista de conteúdo, o app já sabe quais têm dono.
+     */
+    @Column(name = "validation_hash", length = 512)
+    public String validationHash;
+
     // ========== AUDITORIA - DATA E HORA DE CRIAÇÃO E ATUALIZAÇÃO ============
     @Column(name = "created_at", nullable = false, updatable = false)
     @Temporal(TemporalType.TIMESTAMP)

--- a/src/main/java/br/com/aguideptbr/features/ownership/ContentOwnershipController.java
+++ b/src/main/java/br/com/aguideptbr/features/ownership/ContentOwnershipController.java
@@ -1,0 +1,252 @@
+package br.com.aguideptbr.features.ownership;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.jboss.logging.Logger;
+
+import br.com.aguideptbr.features.ownership.dto.OwnershipStatusResponse;
+import br.com.aguideptbr.features.ownership.dto.UserContentResponse;
+import br.com.aguideptbr.features.ownership.dto.ValidateOwnershipRequest;
+import br.com.aguideptbr.features.ownership.dto.ValidateOwnershipResponse;
+import jakarta.validation.Valid;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.PathParam;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+/**
+ * REST Controller for content ownership validation.
+ *
+ * Endpoints:
+ * - POST /api/v1/ownership/validate - Validate content ownership
+ * - GET /api/v1/ownership/user/{userId}/content - List user's verified content
+ * - GET /api/v1/ownership/status - Check ownership status
+ * - GET /api/v1/ownership/pending - List pending ownerships (admin)
+ * - POST /api/v1/ownership/cancel - Cancel ownership claim by user
+ *
+ * Features:
+ * - Idempotent validation with retry tracking
+ * - Audit trail for rejection reasons and attempts
+ * - User cancellation support
+ *
+ * Security:
+ * - All endpoints protected with JWT (AuthenticationFilter)
+ * - User can only validate ownership for their own userId
+ * - HMAC hash always recalculated on backend
+ *
+ * @author System
+ * @since 1.0
+ * @see ContentOwnershipService
+ */
+@Path("/api/v1/ownership")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ContentOwnershipController {
+
+    private final Logger log;
+    private final ContentOwnershipService ownershipService;
+
+    public ContentOwnershipController(Logger log, ContentOwnershipService ownershipService) {
+        this.log = log;
+        this.ownershipService = ownershipService;
+    }
+
+    /**
+     * Validate content ownership.
+     *
+     * Process:
+     * 1. Verify user and content exist
+     * 2. Check if user's youtubeChannelId matches content's channelId
+     * 3. Calculate HMAC-SHA256 hash
+     * 4. Create/update ownership record
+     * 5. Update content_record.validation_hash
+     *
+     * Example request:
+     * POST /api/v1/ownership/validate
+     * {
+     * "userId": "550e8400-e29b-41d4-a716-446655440000",
+     * "contentId": "660e8400-e29b-41d4-a716-446655440001"
+     * }
+     *
+     * @param request ValidateOwnershipRequest with userId and contentId
+     * @return ValidateOwnershipResponse with validation result
+     */
+    @POST
+    @Path("/validate")
+    public Response validateOwnership(@Valid ValidateOwnershipRequest request) {
+        log.infof("POST /api/v1/ownership/validate - userId=%s, contentId=%s",
+                request.getUserId(), request.getContentId());
+
+        try {
+            ValidateOwnershipResponse response = ownershipService.validateOwnership(request);
+
+            if (response.getStatus() == OwnershipStatus.VERIFIED) {
+                log.infof("✅ Ownership validated successfully: ownershipId=%s",
+                        response.getOwnershipId());
+                return Response.ok(response).build();
+            } else {
+                log.warnf("⚠️ Ownership validation rejected: %s", response.getMessage());
+                return Response.status(Response.Status.BAD_REQUEST)
+                        .entity(response)
+                        .build();
+            }
+
+        } catch (Exception e) {
+            log.errorf(e, "❌ Error validating ownership: %s", e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * List all verified content for a specific user.
+     *
+     * Returns content records where ownership has been verified.
+     * Includes both content details and ownership information.
+     *
+     * Example:
+     * GET /api/v1/ownership/user/550e8400-e29b-41d4-a716-446655440000/content
+     *
+     * @param userId User ID
+     * @return List of UserContentResponse with verified content
+     */
+    @GET
+    @Path("/user/{userId}/content")
+    public Response getUserVerifiedContent(@PathParam("userId") UUID userId) {
+        log.infof("GET /api/v1/ownership/user/%s/content - Listing verified content", userId);
+
+        try {
+            List<UserContentResponse> content = ownershipService.getUserVerifiedContent(userId);
+
+            log.infof("✅ Found %d verified content items for user %s",
+                    content.size(), userId);
+
+            return Response.ok(content).build();
+
+        } catch (Exception e) {
+            log.errorf(e, "❌ Error getting user verified content: %s", e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * Check ownership status for specific user and content.
+     *
+     * Returns current ownership status (PENDING, VERIFIED, REJECTED).
+     *
+     * Example:
+     * GET
+     * /api/v1/ownership/status?userId=550e8400-e29b-41d4-a716-446655440000&contentId=660e8400-e29b-41d4-a716-446655440001
+     *
+     * @param userId    User ID (required)
+     * @param contentId Content ID (required)
+     * @return OwnershipStatusResponse with current status
+     */
+    @GET
+    @Path("/status")
+    public Response getOwnershipStatus(
+            @QueryParam("userId") UUID userId,
+            @QueryParam("contentId") UUID contentId) {
+
+        log.infof("GET /api/v1/ownership/status - userId=%s, contentId=%s",
+                userId, contentId);
+
+        if (userId == null || contentId == null) {
+            log.warn("⚠️ Missing required parameters: userId or contentId");
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("userId and contentId are required")
+                    .build();
+        }
+
+        try {
+            OwnershipStatusResponse response = ownershipService.getOwnershipStatus(userId,
+                    contentId);
+
+            log.infof("✅ Ownership status retrieved: status=%s", response.getStatus());
+
+            return Response.ok(response).build();
+
+        } catch (Exception e) {
+            log.errorf(e, "❌ Error getting ownership status: %s", e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * List all pending ownership validations (for admin use).
+     *
+     * Returns ownership records with PENDING status.
+     *
+     * Example:
+     * GET /api/v1/ownership/pending
+     *
+     * @return List of ContentOwnershipModel with PENDING status
+     */
+    @GET
+    @Path("/pending")
+    public Response getPendingOwnerships() {
+        log.info("GET /api/v1/ownership/pending - Listing pending ownerships");
+
+        try {
+            List<ContentOwnershipModel> pending = ContentOwnershipModel.findPending();
+
+            log.infof("✅ Found %d pending ownerships", pending.size());
+
+            return Response.ok(pending).build();
+
+        } catch (Exception e) {
+            log.errorf(e, "❌ Error getting pending ownerships: %s", e.getMessage());
+            throw e;
+        }
+    }
+
+    /**
+     * Cancel ownership claim by user.
+     *
+     * Marks ownership as REJECTED with reason USER_CANCELLED.
+     * Sets cancelled_by_user = true for audit purposes.
+     *
+     * Example:
+     * POST
+     * /api/v1/ownership/cancel?userId=550e8400-e29b-41d4-a716-446655440000&contentId=660e8400-e29b-41d4-a716-446655440001
+     *
+     * @param userId    User ID (required)
+     * @param contentId Content ID (required)
+     * @return ValidateOwnershipResponse with cancellation result
+     */
+    @POST
+    @Path("/cancel")
+    public Response cancelOwnership(
+            @QueryParam("userId") UUID userId,
+            @QueryParam("contentId") UUID contentId) {
+
+        log.infof("POST /api/v1/ownership/cancel - userId=%s, contentId=%s",
+                userId, contentId);
+
+        if (userId == null || contentId == null) {
+            log.warn("⚠️ Missing required parameters: userId or contentId");
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity("userId and contentId are required")
+                    .build();
+        }
+
+        try {
+            ValidateOwnershipResponse response = ownershipService.cancelOwnershipClaim(userId,
+                    contentId);
+
+            log.infof("✅ Ownership cancelled successfully: ownershipId=%s",
+                    response.getOwnershipId());
+
+            return Response.ok(response).build();
+
+        } catch (Exception e) {
+            log.errorf(e, "❌ Error cancelling ownership: %s", e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/src/main/java/br/com/aguideptbr/features/ownership/ContentOwnershipModel.java
+++ b/src/main/java/br/com/aguideptbr/features/ownership/ContentOwnershipModel.java
@@ -1,0 +1,323 @@
+package br.com.aguideptbr.features.ownership;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import io.quarkus.hibernate.orm.panache.PanacheEntityBase;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.UniqueConstraint;
+
+/**
+ * Entity representing content ownership validation.
+ *
+ * This table acts as a soft reference between users (app_user) and content
+ * (content_record), validating ownership through HMAC-SHA256 cryptographic
+ * verification.
+ *
+ * Soft references are used instead of rigid foreign keys because:
+ * - Data comes from external sources (YouTube API)
+ * - Lifecycles are independent
+ * - Data may be changed/deleted externally
+ */
+@Entity
+@Table(name = "content_ownership", uniqueConstraints = {
+        @UniqueConstraint(name = "uk_ownership_user_content", columnNames = { "user_id", "content_id" })
+})
+public class ContentOwnershipModel extends PanacheEntityBase {
+
+    // ========== IDENTIFICAÇÃO ==========
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    public UUID id;
+
+    // ========== SOFT REFERENCES (não usa FK rígidas) ==========
+
+    /**
+     * Soft reference to app_user.id.
+     * No rigid FK because user data may come from external OAuth providers.
+     */
+    @Column(name = "user_id", nullable = false)
+    public UUID userId;
+
+    /**
+     * Soft reference to content_record.id.
+     * No rigid FK because content data comes from YouTube API.
+     */
+    @Column(name = "content_id", nullable = false)
+    public UUID contentId;
+
+    // ========== CAMPOS DE VALIDAÇÃO ==========
+
+    /**
+     * YouTube Channel ID from user (app_user.youtube_channel_id).
+     * Captured at validation time (snapshot for audit).
+     */
+    @Column(name = "youtube_channel_id", nullable = false, length = 255)
+    public String youtubeChannelId;
+
+    /**
+     * YouTube Channel ID from content (content_record.channel_id).
+     * Captured at validation time (snapshot for audit).
+     */
+    @Column(name = "content_channel_id", nullable = false, length = 255)
+    public String contentChannelId;
+
+    /**
+     * Ownership validation status.
+     * - PENDING: Awaiting validation
+     * - VERIFIED: HMAC validated, channels match
+     * - REJECTED: HMAC invalid or channels mismatch
+     *
+     * NOTE: Database column is VARCHAR(20) with CHECK constraint (changed in
+     * V1.0.17).
+     * JPA @Enumerated(EnumType.STRING) maps naturally to VARCHAR.
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "ownership_status", nullable = false, length = 20)
+    public OwnershipStatus ownershipStatus = OwnershipStatus.PENDING;
+
+    /**
+     * HMAC-SHA256 validation hash.
+     * Calculated: HMAC(userId + contentId + channelIds, secret)
+     * Always recalculated on backend (never trust client).
+     */
+    @Column(name = "validation_hash", nullable = false, length = 512)
+    public String validationHash;
+
+    // ========== AUDITORIA DE VERIFICAÇÃO ==========
+
+    /**
+     * Timestamp when ownership was verified.
+     * Null if still PENDING or REJECTED.
+     */
+    @Column(name = "verified_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    public LocalDateTime verifiedAt;
+
+    /**
+     * Admin user ID who manually verified (optional).
+     * Null for automatic verification.
+     */
+    @Column(name = "verified_by")
+    public UUID verifiedBy;
+
+    // ========== CAMPOS DE AUDITORIA E RETRY ==========
+
+    /**
+     * Detailed rejection reason.
+     * Values: CHANNEL_MISMATCH, NO_CHANNEL, USER_CANCELLED, etc.
+     * Null when status = VERIFIED.
+     */
+    @Column(name = "rejection_reason", columnDefinition = "TEXT")
+    public String rejectionReason;
+
+    /**
+     * Number of validation attempts (retry counter).
+     * Starts at 0 on first attempt, incremented on each retry.
+     * Useful for analytics and rate limiting.
+     */
+    @Column(name = "retry_count", nullable = false)
+    public Integer retryCount = 0;
+
+    /**
+     * Timestamp of last validation attempt (success or failure).
+     * Updated on every validation request.
+     */
+    @Column(name = "last_attempt_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    public LocalDateTime lastAttemptAt;
+
+    /**
+     * Whether the ownership claim was cancelled by the user.
+     * true = user explicitly cancelled the claim
+     * false = system automatically rejected (default)
+     */
+    @Column(name = "cancelled_by_user", nullable = false)
+    public Boolean cancelledByUser = false;
+
+    // ========== TIMESTAMPS DE AUDITORIA ==========
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    @Temporal(TemporalType.TIMESTAMP)
+    private LocalDateTime updatedAt;
+
+    /**
+     * Automatically sets the creation timestamp before persisting the entity.
+     */
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+        // Set last attempt timestamp on creation
+        if (lastAttemptAt == null) {
+            lastAttemptAt = LocalDateTime.now();
+        }
+    }
+
+    /**
+     * Automatically updates the modification timestamp before updating the entity.
+     */
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+
+    // ========== GETTERS E SETTERS ==========
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    // ========== MÉTODOS DE BUSCA ==========
+
+    /**
+     * Find all ownerships for a specific user.
+     *
+     * @param userId User ID
+     * @return List of ContentOwnershipModel
+     */
+    public static List<ContentOwnershipModel> findByUserId(UUID userId) {
+        return list("userId", userId);
+    }
+
+    /**
+     * Find all verified ownerships for a specific user.
+     *
+     * @param userId User ID
+     * @return List of verified ContentOwnershipModel
+     */
+    public static List<ContentOwnershipModel> findVerifiedByUserId(UUID userId) {
+        return list("userId = ?1 and ownershipStatus = ?2", userId, OwnershipStatus.VERIFIED);
+    }
+
+    /**
+     * Find ownership by user and content.
+     *
+     * @param userId    User ID
+     * @param contentId Content ID
+     * @return ContentOwnershipModel or null
+     */
+    public static ContentOwnershipModel findByUserAndContent(UUID userId, UUID contentId) {
+        return find("userId = ?1 and contentId = ?2", userId, contentId).firstResult();
+    }
+
+    /**
+     * Find all ownerships for a specific content.
+     *
+     * @param contentId Content ID
+     * @return List of ContentOwnershipModel
+     */
+    public static List<ContentOwnershipModel> findByContentId(UUID contentId) {
+        return list("contentId", contentId);
+    }
+
+    /**
+     * Find all ownerships by status.
+     *
+     * @param status Ownership status
+     * @return List of ContentOwnershipModel
+     */
+    public static List<ContentOwnershipModel> findByStatus(OwnershipStatus status) {
+        return list("ownershipStatus", status);
+    }
+
+    /**
+     * Find all pending ownerships (awaiting validation).
+     *
+     * @return List of pending ContentOwnershipModel
+     */
+    public static List<ContentOwnershipModel> findPending() {
+        return list("ownershipStatus", OwnershipStatus.PENDING);
+    }
+
+    /**
+     * Check if ownership exists (regardless of status).
+     *
+     * @param userId    User ID
+     * @param contentId Content ID
+     * @return true if ownership exists
+     */
+    public static boolean ownershipExists(UUID userId, UUID contentId) {
+        return count("userId = ?1 and contentId = ?2", userId, contentId) > 0;
+    }
+
+    /**
+     * Check if verified ownership exists.
+     *
+     * @param userId    User ID
+     * @param contentId Content ID
+     * @return true if verified ownership exists
+     */
+
+    /**
+     * Find all ownerships with retry count greater than threshold.
+     * Useful for identifying users with multiple failed attempts.
+     *
+     * @param threshold Minimum retry count
+     * @return List of ContentOwnershipModel
+     */
+    public static List<ContentOwnershipModel> findWithHighRetryCount(int threshold) {
+        return list("retryCount >= ?1", threshold);
+    }
+
+    /**
+     * Find all user-cancelled ownerships.
+     *
+     * @return List of ContentOwnershipModel
+     */
+    public static List<ContentOwnershipModel> findCancelledByUser() {
+        return list("cancelledByUser = true");
+    }
+
+    /**
+     * Increment retry counter and update last attempt timestamp.
+     * Call this method on every validation attempt.
+     */
+    public void recordAttempt() {
+        this.retryCount++;
+        this.lastAttemptAt = LocalDateTime.now();
+    }
+
+    /**
+     * Mark ownership as cancelled by user.
+     */
+    public void cancelByUser() {
+        this.cancelledByUser = true;
+        this.ownershipStatus = OwnershipStatus.REJECTED;
+        this.rejectionReason = "USER_CANCELLED";
+        this.lastAttemptAt = LocalDateTime.now();
+    }
+
+    /**
+     * Reset retry counter (for admin use).
+     * Useful when helping users troubleshoot issues.
+     */
+    public void resetRetryCount() {
+        this.retryCount = 0;
+    }
+
+    public static boolean isVerified(UUID userId, UUID contentId) {
+        return count("userId = ?1 and contentId = ?2 and ownershipStatus = ?3",
+                userId, contentId, OwnershipStatus.VERIFIED) > 0;
+    }
+}

--- a/src/main/java/br/com/aguideptbr/features/ownership/ContentOwnershipService.java
+++ b/src/main/java/br/com/aguideptbr/features/ownership/ContentOwnershipService.java
@@ -1,0 +1,404 @@
+package br.com.aguideptbr.features.ownership;
+
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import br.com.aguideptbr.features.content.ContentRecordModel;
+import br.com.aguideptbr.features.ownership.dto.OwnershipStatusResponse;
+import br.com.aguideptbr.features.ownership.dto.UserContentResponse;
+import br.com.aguideptbr.features.ownership.dto.ValidateOwnershipRequest;
+import br.com.aguideptbr.features.ownership.dto.ValidateOwnershipResponse;
+import br.com.aguideptbr.features.user.UserModel;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.transaction.Transactional;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.Response.Status;
+
+/**
+ * Service responsible for content ownership validation using HMAC-SHA256
+ * cryptographic verification.
+ *
+ * Security model:
+ * - User's youtubeChannelId must match content's channelId
+ * - HMAC hash is ALWAYS recalculated on backend (never trust client)
+ * - Secret key managed via environment variable
+ * - User can only validate ownership for their own userId
+ */
+@ApplicationScoped
+public class ContentOwnershipService {
+
+    private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+    private final Logger log;
+    private final String ownershipSecretKey;
+
+    public ContentOwnershipService(
+            Logger log,
+            @ConfigProperty(name = "ownership.validation.secret") String ownershipSecretKey) {
+        this.log = log;
+        this.ownershipSecretKey = ownershipSecretKey;
+    }
+
+    /**
+     * Validates content ownership by checking channel IDs and generating HMAC
+     * hash.
+     *
+     * IDEMPOTENCY: Multiple calls with same userId+contentId update the same
+     * record.
+     * Each attempt increments retry_count and updates last_attempt_at.
+     *
+     * Process:
+     * 1. Verify user and content exist
+     * 2. Check if user has YouTube channel ID
+     * 3. Verify channel IDs match
+     * 4. Calculate HMAC-SHA256 hash
+     * 5. Create/update ownership record (IDEMPOTENT)
+     * 6. Update content_record.validation_hash if verified
+     *
+     * @param request Validation request with userId and contentId
+     * @return ValidateOwnershipResponse with validation result
+     * @throws WebApplicationException if validation fails
+     */
+    @Transactional
+    public ValidateOwnershipResponse validateOwnership(ValidateOwnershipRequest request) {
+        log.infof("🔐 Validating ownership: userId=%s, contentId=%s",
+                request.getUserId(), request.getContentId());
+
+        // 1. Verify user exists
+        UserModel user = UserModel.findById(request.getUserId());
+        if (user == null || user.deletedAt != null) {
+            log.warnf("⚠️ User not found or deleted: %s", request.getUserId());
+            throw new WebApplicationException("User not found", Status.NOT_FOUND);
+        }
+
+        // 2. Verify content exists
+        ContentRecordModel content = ContentRecordModel.findById(request.getContentId());
+        if (content == null) {
+            log.warnf("⚠️ Content not found: %s", request.getContentId());
+            throw new WebApplicationException("Content not found", Status.NOT_FOUND);
+        }
+
+        // 3. Check if ownership already exists (IDEMPOTENCY)
+        ContentOwnershipModel ownership = ContentOwnershipModel.findByUserAndContent(
+                request.getUserId(), request.getContentId());
+
+        // 4. Check if user has YouTube channel ID
+        if (user.youtubeChannelId == null || user.youtubeChannelId.isBlank()) {
+            log.warnf("⚠️ User has no YouTube channel ID: %s", user.id);
+            return buildRejectedResponse(
+                    ownership,
+                    request.getUserId(),
+                    request.getContentId(),
+                    user.youtubeChannelId,
+                    content.channelId,
+                    "NO_CHANNEL",
+                    "User has no YouTube channel ID");
+        }
+
+        // 5. Verify channel IDs match
+        boolean channelsMatch = user.youtubeChannelId.equals(content.channelId);
+        if (!channelsMatch) {
+            log.warnf("⚠️ Channel IDs mismatch: user=%s, content=%s",
+                    user.youtubeChannelId, content.channelId);
+            return buildRejectedResponse(
+                    ownership,
+                    request.getUserId(),
+                    request.getContentId(),
+                    user.youtubeChannelId,
+                    content.channelId,
+                    "CHANNEL_MISMATCH",
+                    "Channel IDs do not match");
+        }
+
+        // 6. Calculate HMAC-SHA256 hash
+        String validationHash = calculateHMAC(
+                request.getUserId(),
+                request.getContentId(),
+                user.youtubeChannelId,
+                content.channelId);
+
+        // 7. Update or create ownership (IDEMPOTENT)
+        if (ownership != null) {
+            log.infof("ℹ️ Ownership exists (retry #%d), updating to VERIFIED", ownership.retryCount);
+            ownership.ownershipStatus = OwnershipStatus.VERIFIED;
+            ownership.validationHash = validationHash;
+            ownership.verifiedAt = LocalDateTime.now();
+            ownership.rejectionReason = null; // Clear previous rejection
+            ownership.cancelledByUser = false; // Reset cancellation flag
+            ownership.recordAttempt(); // Increment retry_count and update last_attempt_at
+            ownership.persist();
+        } else {
+            log.infof("✅ Creating new verified ownership");
+            ownership = new ContentOwnershipModel();
+            ownership.userId = request.getUserId();
+            ownership.contentId = request.getContentId();
+            ownership.youtubeChannelId = user.youtubeChannelId;
+            ownership.contentChannelId = content.channelId;
+            ownership.ownershipStatus = OwnershipStatus.VERIFIED;
+            ownership.validationHash = validationHash;
+            ownership.verifiedAt = LocalDateTime.now();
+            ownership.retryCount = 0; // First attempt
+            ownership.lastAttemptAt = LocalDateTime.now();
+            ownership.persist();
+        }
+
+        // 8. Update content_record.validation_hash for fast queries
+        content.validationHash = validationHash;
+        content.persist();
+
+        log.infof("✅ Ownership validated successfully: ownershipId=%s, retryCount=%d",
+                ownership.id, ownership.retryCount);
+
+        return new ValidateOwnershipResponse(
+                ownership.id,
+                ownership.userId,
+                ownership.contentId,
+                ownership.youtubeChannelId,
+                ownership.contentChannelId,
+                ownership.ownershipStatus,
+                ownership.validationHash,
+                ownership.verifiedAt,
+                ownership.getCreatedAt(),
+                "Ownership validated successfully");
+    }
+
+    /**
+     * Get ownership status for specific user and content.
+     *
+     * @param userId    User ID
+     * @param contentId Content ID
+     * @return OwnershipStatusResponse with current status
+     * @throws WebApplicationException if ownership not found
+     */
+    public OwnershipStatusResponse getOwnershipStatus(UUID userId, UUID contentId) {
+        log.infof("ℹ️ Getting ownership status: userId=%s, contentId=%s", userId, contentId);
+
+        ContentOwnershipModel ownership = ContentOwnershipModel.findByUserAndContent(userId,
+                contentId);
+
+        if (ownership == null) {
+            log.warnf("⚠️ Ownership not found: userId=%s, contentId=%s", userId, contentId);
+            throw new WebApplicationException("Ownership not found", Status.NOT_FOUND);
+        }
+
+        boolean channelsMatch = ownership.youtubeChannelId.equals(ownership.contentChannelId);
+        boolean isVerified = ownership.ownershipStatus == OwnershipStatus.VERIFIED;
+
+        return new OwnershipStatusResponse(
+                ownership.id,
+                ownership.userId,
+                ownership.contentId,
+                ownership.ownershipStatus,
+                isVerified,
+                channelsMatch,
+                ownership.verifiedAt,
+                ownership.getCreatedAt());
+    }
+
+    /**
+     * Get all verified content for a user.
+     *
+     * @param userId User ID
+     * @return List of UserContentResponse with verified content
+     */
+    public List<UserContentResponse> getUserVerifiedContent(UUID userId) {
+        log.infof("ℹ️ Getting verified content for user: %s", userId);
+
+        List<ContentOwnershipModel> verifiedOwnerships = ContentOwnershipModel
+                .findVerifiedByUserId(userId);
+
+        List<UserContentResponse> contentList = new ArrayList<>();
+
+        for (ContentOwnershipModel ownership : verifiedOwnerships) {
+            ContentRecordModel content = ContentRecordModel.findById(ownership.contentId);
+
+            if (content != null) {
+                UserContentResponse response = new UserContentResponse(
+                        content.id,
+                        content.title,
+                        content.description,
+                        content.videoUrl,
+                        content.videoThumbnailUrl,
+                        content.channelId,
+                        content.channelName,
+                        content.getPublishedAt(),
+                        ownership.id,
+                        ownership.validationHash,
+                        ownership.verifiedAt,
+                        true);
+
+                contentList.add(response);
+            }
+        }
+
+        log.infof("✅ Found %d verified content items for user %s",
+                contentList.size(), userId);
+
+        return contentList;
+    }
+
+    /**
+     * Calculate HMAC-SHA256 hash for ownership validation.
+     *
+     * Formula: HMAC(userId + contentId + youtubeChannelId + contentChannelId,
+     * secretKey)
+     *
+     * @param userId           User ID
+     * @param contentId        Content ID
+     * @param youtubeChannelId YouTube channel ID from user
+     * @param contentChannelId YouTube channel ID from content
+     * @return Hexadecimal HMAC-SHA256 hash
+     */
+    private String calculateHMAC(
+            UUID userId,
+            UUID contentId,
+            String youtubeChannelId,
+            String contentChannelId) {
+
+        try {
+            // Build data string
+            String data = userId.toString() +
+                    contentId.toString() +
+                    youtubeChannelId +
+                    contentChannelId;
+
+            // Create HMAC instance
+            Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+            SecretKeySpec secretKeySpec = new SecretKeySpec(
+                    ownershipSecretKey.getBytes(StandardCharsets.UTF_8),
+                    HMAC_ALGORITHM);
+            mac.init(secretKeySpec);
+
+            // Calculate hash
+            byte[] hashBytes = mac.doFinal(data.getBytes(StandardCharsets.UTF_8));
+
+            // Convert to hexadecimal
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hashBytes) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
+            }
+
+            return hexString.toString();
+
+        } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+            log.errorf(e, "❌ Error calculating HMAC: %s", e.getMessage());
+            throw new WebApplicationException(
+                    "Error calculating validation hash",
+                    Status.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Build rejected ownership response with retry tracking.
+     *
+     * IDEMPOTENCY: Updates existing ownership or creates new one.
+     * Increments retry_count and records rejection_reason.
+     *
+     * NOTE: No @Transactional needed - this private method is called from
+     * validateOwnership() which already has @Transactional.
+     */
+    private ValidateOwnershipResponse buildRejectedResponse(
+            ContentOwnershipModel existingOwnership,
+            UUID userId,
+            UUID contentId,
+            String youtubeChannelId,
+            String contentChannelId,
+            String rejectionReason,
+            String message) {
+
+        ContentOwnershipModel ownership;
+
+        if (existingOwnership != null) {
+            // Update existing ownership (RETRY)
+            log.infof("ℹ️ Updating existing ownership to REJECTED (retry #%d)",
+                    existingOwnership.retryCount);
+            ownership = existingOwnership;
+            ownership.ownershipStatus = OwnershipStatus.REJECTED;
+            ownership.rejectionReason = rejectionReason;
+            ownership.recordAttempt(); // Increment retry_count and update timestamp
+            ownership.persist();
+        } else {
+            // Create new rejected ownership
+            log.infof("⚠️ Creating new REJECTED ownership: %s", rejectionReason);
+            ownership = new ContentOwnershipModel();
+            ownership.userId = userId;
+            ownership.contentId = contentId;
+            ownership.youtubeChannelId = youtubeChannelId != null ? youtubeChannelId : "";
+            ownership.contentChannelId = contentChannelId != null ? contentChannelId : "";
+            ownership.ownershipStatus = OwnershipStatus.REJECTED;
+            ownership.rejectionReason = rejectionReason;
+            ownership.validationHash = ""; // No hash for rejected
+            ownership.retryCount = 0; // First attempt
+            ownership.lastAttemptAt = LocalDateTime.now();
+            ownership.persist();
+        }
+
+        return new ValidateOwnershipResponse(
+                ownership.id,
+                ownership.userId,
+                ownership.contentId,
+                ownership.youtubeChannelId,
+                ownership.contentChannelId,
+                ownership.ownershipStatus,
+                "",
+                null,
+                ownership.getCreatedAt(),
+                message);
+    }
+
+    /**
+     * Cancel ownership claim by user.
+     * Sets status to REJECTED with reason USER_CANCELLED.
+     *
+     * @param userId    User ID
+     * @param contentId Content ID
+     * @return ValidateOwnershipResponse with cancellation result
+     * @throws WebApplicationException if ownership not found
+     */
+    @Transactional
+    public ValidateOwnershipResponse cancelOwnershipClaim(UUID userId, UUID contentId) {
+        log.infof("🚫 Cancelling ownership claim: userId=%s, contentId=%s", userId, contentId);
+
+        ContentOwnershipModel ownership = ContentOwnershipModel.findByUserAndContent(userId,
+                contentId);
+
+        if (ownership == null) {
+            log.warnf("⚠️ Ownership not found for cancellation: userId=%s, contentId=%s",
+                    userId, contentId);
+            throw new WebApplicationException("Ownership not found", Status.NOT_FOUND);
+        }
+
+        // Mark as cancelled by user
+        ownership.cancelByUser();
+        ownership.persist();
+
+        log.infof("✅ Ownership cancelled by user: ownershipId=%s", ownership.id);
+
+        return new ValidateOwnershipResponse(
+                ownership.id,
+                ownership.userId,
+                ownership.contentId,
+                ownership.youtubeChannelId,
+                ownership.contentChannelId,
+                ownership.ownershipStatus,
+                "",
+                null,
+                ownership.getCreatedAt(),
+                "Ownership claim cancelled by user");
+    }
+}

--- a/src/main/java/br/com/aguideptbr/features/ownership/OwnershipStatus.java
+++ b/src/main/java/br/com/aguideptbr/features/ownership/OwnershipStatus.java
@@ -1,0 +1,28 @@
+package br.com.aguideptbr.features.ownership;
+
+/**
+ * Enum representing the status of content ownership validation.
+ *
+ * - PENDING: Ownership claim awaiting validation
+ * - VERIFIED: Ownership validated successfully (HMAC match)
+ * - REJECTED: Ownership validation failed (HMAC mismatch or channel mismatch)
+ */
+public enum OwnershipStatus {
+    /**
+     * Ownership claim created but not yet validated.
+     */
+    PENDING,
+
+    /**
+     * Ownership validated successfully.
+     * User's YouTube channel ID matches content's channel ID,
+     * and HMAC signature is valid.
+     */
+    VERIFIED,
+
+    /**
+     * Ownership validation failed.
+     * Either channel IDs don't match or HMAC signature is invalid.
+     */
+    REJECTED
+}

--- a/src/main/java/br/com/aguideptbr/features/ownership/dto/OwnershipStatusResponse.java
+++ b/src/main/java/br/com/aguideptbr/features/ownership/dto/OwnershipStatusResponse.java
@@ -1,0 +1,111 @@
+package br.com.aguideptbr.features.ownership.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import br.com.aguideptbr.features.ownership.OwnershipStatus;
+
+/**
+ * DTO for ownership status query response.
+ *
+ * Used to check the current ownership status of a specific content.
+ */
+public class OwnershipStatusResponse {
+
+    private UUID ownershipId;
+    private UUID userId;
+    private UUID contentId;
+    private OwnershipStatus status;
+    private boolean isVerified;
+    private boolean channelsMatch;
+    private LocalDateTime verifiedAt;
+    private LocalDateTime createdAt;
+
+    // Construtores
+    public OwnershipStatusResponse() {
+    }
+
+    public OwnershipStatusResponse(
+            UUID ownershipId,
+            UUID userId,
+            UUID contentId,
+            OwnershipStatus status,
+            boolean isVerified,
+            boolean channelsMatch,
+            LocalDateTime verifiedAt,
+            LocalDateTime createdAt) {
+        this.ownershipId = ownershipId;
+        this.userId = userId;
+        this.contentId = contentId;
+        this.status = status;
+        this.isVerified = isVerified;
+        this.channelsMatch = channelsMatch;
+        this.verifiedAt = verifiedAt;
+        this.createdAt = createdAt;
+    }
+
+    // Getters e Setters
+    public UUID getOwnershipId() {
+        return ownershipId;
+    }
+
+    public void setOwnershipId(UUID ownershipId) {
+        this.ownershipId = ownershipId;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getContentId() {
+        return contentId;
+    }
+
+    public void setContentId(UUID contentId) {
+        this.contentId = contentId;
+    }
+
+    public OwnershipStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OwnershipStatus status) {
+        this.status = status;
+    }
+
+    public boolean isVerified() {
+        return isVerified;
+    }
+
+    public void setVerified(boolean verified) {
+        isVerified = verified;
+    }
+
+    public boolean isChannelsMatch() {
+        return channelsMatch;
+    }
+
+    public void setChannelsMatch(boolean channelsMatch) {
+        this.channelsMatch = channelsMatch;
+    }
+
+    public LocalDateTime getVerifiedAt() {
+        return verifiedAt;
+    }
+
+    public void setVerifiedAt(LocalDateTime verifiedAt) {
+        this.verifiedAt = verifiedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+}

--- a/src/main/java/br/com/aguideptbr/features/ownership/dto/UserContentResponse.java
+++ b/src/main/java/br/com/aguideptbr/features/ownership/dto/UserContentResponse.java
@@ -1,0 +1,156 @@
+package br.com.aguideptbr.features.ownership.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * DTO for user's verified content response.
+ *
+ * Includes both content details and ownership information.
+ */
+public class UserContentResponse {
+
+    // Content information
+    private UUID contentId;
+    private String title;
+    private String description;
+    private String videoUrl;
+    private String videoThumbnailUrl;
+    private String channelId;
+    private String channelName;
+    private LocalDateTime publishedAt;
+
+    // Ownership information
+    private UUID ownershipId;
+    private String validationHash;
+    private LocalDateTime verifiedAt;
+    private boolean isVerified;
+
+    // Construtores
+    public UserContentResponse() {
+    }
+
+    public UserContentResponse(
+            UUID contentId,
+            String title,
+            String description,
+            String videoUrl,
+            String videoThumbnailUrl,
+            String channelId,
+            String channelName,
+            LocalDateTime publishedAt,
+            UUID ownershipId,
+            String validationHash,
+            LocalDateTime verifiedAt,
+            boolean isVerified) {
+        this.contentId = contentId;
+        this.title = title;
+        this.description = description;
+        this.videoUrl = videoUrl;
+        this.videoThumbnailUrl = videoThumbnailUrl;
+        this.channelId = channelId;
+        this.channelName = channelName;
+        this.publishedAt = publishedAt;
+        this.ownershipId = ownershipId;
+        this.validationHash = validationHash;
+        this.verifiedAt = verifiedAt;
+        this.isVerified = isVerified;
+    }
+
+    // Getters e Setters
+    public UUID getContentId() {
+        return contentId;
+    }
+
+    public void setContentId(UUID contentId) {
+        this.contentId = contentId;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getVideoUrl() {
+        return videoUrl;
+    }
+
+    public void setVideoUrl(String videoUrl) {
+        this.videoUrl = videoUrl;
+    }
+
+    public String getVideoThumbnailUrl() {
+        return videoThumbnailUrl;
+    }
+
+    public void setVideoThumbnailUrl(String videoThumbnailUrl) {
+        this.videoThumbnailUrl = videoThumbnailUrl;
+    }
+
+    public String getChannelId() {
+        return channelId;
+    }
+
+    public void setChannelId(String channelId) {
+        this.channelId = channelId;
+    }
+
+    public String getChannelName() {
+        return channelName;
+    }
+
+    public void setChannelName(String channelName) {
+        this.channelName = channelName;
+    }
+
+    public LocalDateTime getPublishedAt() {
+        return publishedAt;
+    }
+
+    public void setPublishedAt(LocalDateTime publishedAt) {
+        this.publishedAt = publishedAt;
+    }
+
+    public UUID getOwnershipId() {
+        return ownershipId;
+    }
+
+    public void setOwnershipId(UUID ownershipId) {
+        this.ownershipId = ownershipId;
+    }
+
+    public String getValidationHash() {
+        return validationHash;
+    }
+
+    public void setValidationHash(String validationHash) {
+        this.validationHash = validationHash;
+    }
+
+    public LocalDateTime getVerifiedAt() {
+        return verifiedAt;
+    }
+
+    public void setVerifiedAt(LocalDateTime verifiedAt) {
+        this.verifiedAt = verifiedAt;
+    }
+
+    public boolean isVerified() {
+        return isVerified;
+    }
+
+    public void setVerified(boolean verified) {
+        isVerified = verified;
+    }
+}

--- a/src/main/java/br/com/aguideptbr/features/ownership/dto/ValidateOwnershipRequest.java
+++ b/src/main/java/br/com/aguideptbr/features/ownership/dto/ValidateOwnershipRequest.java
@@ -1,0 +1,50 @@
+package br.com.aguideptbr.features.ownership.dto;
+
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotNull;
+
+/**
+ * DTO for content ownership validation request.
+ *
+ * This request is sent by the Flutter app to validate ownership of content.
+ * The backend will:
+ * 1. Verify user's youtubeChannelId matches content's channelId
+ * 2. Calculate HMAC-SHA256 hash
+ * 3. Create/update ownership record
+ * 4. Update content_record.validation_hash if verified
+ */
+public class ValidateOwnershipRequest {
+
+    @NotNull(message = "User ID é obrigatório")
+    private UUID userId;
+
+    @NotNull(message = "Content ID é obrigatório")
+    private UUID contentId;
+
+    // Construtores
+    public ValidateOwnershipRequest() {
+    }
+
+    public ValidateOwnershipRequest(UUID userId, UUID contentId) {
+        this.userId = userId;
+        this.contentId = contentId;
+    }
+
+    // Getters e Setters
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getContentId() {
+        return contentId;
+    }
+
+    public void setContentId(UUID contentId) {
+        this.contentId = contentId;
+    }
+}

--- a/src/main/java/br/com/aguideptbr/features/ownership/dto/ValidateOwnershipResponse.java
+++ b/src/main/java/br/com/aguideptbr/features/ownership/dto/ValidateOwnershipResponse.java
@@ -1,0 +1,133 @@
+package br.com.aguideptbr.features.ownership.dto;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import br.com.aguideptbr.features.ownership.OwnershipStatus;
+
+/**
+ * DTO for content ownership validation response.
+ *
+ * Returned after validating ownership claim.
+ */
+public class ValidateOwnershipResponse {
+
+    private UUID ownershipId;
+    private UUID userId;
+    private UUID contentId;
+    private String youtubeChannelId;
+    private String contentChannelId;
+    private OwnershipStatus status;
+    private String validationHash;
+    private LocalDateTime verifiedAt;
+    private LocalDateTime createdAt;
+    private String message;
+
+    // Construtores
+    public ValidateOwnershipResponse() {
+    }
+
+    public ValidateOwnershipResponse(
+            UUID ownershipId,
+            UUID userId,
+            UUID contentId,
+            String youtubeChannelId,
+            String contentChannelId,
+            OwnershipStatus status,
+            String validationHash,
+            LocalDateTime verifiedAt,
+            LocalDateTime createdAt,
+            String message) {
+        this.ownershipId = ownershipId;
+        this.userId = userId;
+        this.contentId = contentId;
+        this.youtubeChannelId = youtubeChannelId;
+        this.contentChannelId = contentChannelId;
+        this.status = status;
+        this.validationHash = validationHash;
+        this.verifiedAt = verifiedAt;
+        this.createdAt = createdAt;
+        this.message = message;
+    }
+
+    // Getters e Setters
+    public UUID getOwnershipId() {
+        return ownershipId;
+    }
+
+    public void setOwnershipId(UUID ownershipId) {
+        this.ownershipId = ownershipId;
+    }
+
+    public UUID getUserId() {
+        return userId;
+    }
+
+    public void setUserId(UUID userId) {
+        this.userId = userId;
+    }
+
+    public UUID getContentId() {
+        return contentId;
+    }
+
+    public void setContentId(UUID contentId) {
+        this.contentId = contentId;
+    }
+
+    public String getYoutubeChannelId() {
+        return youtubeChannelId;
+    }
+
+    public void setYoutubeChannelId(String youtubeChannelId) {
+        this.youtubeChannelId = youtubeChannelId;
+    }
+
+    public String getContentChannelId() {
+        return contentChannelId;
+    }
+
+    public void setContentChannelId(String contentChannelId) {
+        this.contentChannelId = contentChannelId;
+    }
+
+    public OwnershipStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OwnershipStatus status) {
+        this.status = status;
+    }
+
+    public String getValidationHash() {
+        return validationHash;
+    }
+
+    public void setValidationHash(String validationHash) {
+        this.validationHash = validationHash;
+    }
+
+    public LocalDateTime getVerifiedAt() {
+        return verifiedAt;
+    }
+
+    public void setVerifiedAt(LocalDateTime verifiedAt) {
+        this.verifiedAt = verifiedAt;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -48,6 +48,12 @@ quarkus.swagger-ui.path=/q/swagger-ui
 # Informações da API exibidas no Swagger
 quarkus.smallrye-openapi.info-title=Mobile REST API
 quarkus.smallrye-openapi.info-version=1.0.0
+
+# ========== OWNERSHIP VALIDATION (DEV) ==========
+# 🔒 SEGURANÇA: Chave secreta para validação HMAC (desenvolvimento)
+# Usa variável de ambiente do .env para evitar hardcoding (Sonar compliance)
+# Gere uma chave com: openssl rand -hex 32
+ownership.validation.secret=${OWNERSHIP_VALIDATION_SECRET}
 quarkus.smallrye-openapi.info-description=API REST para gerenciamento de conteúdos e usuários
 quarkus.smallrye-openapi.info-contact-name=Equipe de Desenvolvimento
 quarkus.smallrye-openapi.info-contact-email=dev@aguideptbr.com.br

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -46,3 +46,9 @@ quarkus.log.console.format=%d{yyyy-MM-dd HH:mm:ss} %-5p [%c{2.}] %s%e%n
 quarkus.swagger-ui.enable=false
 quarkus.swagger-ui.always-include=false
 
+# ========== OWNERSHIP VALIDATION (PROD) ==========
+# 🔒 SEGURANÇA CRÍTICA: Chave secreta para validação HMAC
+# OBRIGATÓRIO: Use variável de ambiente em produção!
+# NUNCA commite a chave de produção no Git
+# Defina OWNERSHIP_VALIDATION_SECRET no docker-compose.yml ou no ambiente VPS
+ownership.validation.secret=${OWNERSHIP_VALIDATION_SECRET}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -105,3 +105,11 @@ quarkus.smallrye-jwt.enabled=false
 #
 # Para alternar entre ambientes, configure a variável:
 #   QUARKUS_PROFILE=dev   ou   QUARKUS_PROFILE=prod
+
+# ========== CONTENT OWNERSHIP VALIDATION ==========
+# 🔒 SEGURANÇA: Chave secreta para HMAC-SHA256 de validação de propriedade
+# OBRIGATÓRIO: Defina OWNERSHIP_VALIDATION_SECRET no arquivo .env
+# Mínimo 32 caracteres para garantir segurança adequada
+# Gere com: openssl rand -hex 32
+# Sonar Compliance: Sem fallback hardcoded!
+ownership.validation.secret=${OWNERSHIP_VALIDATION_SECRET}

--- a/src/main/resources/db/migration/V1.0.14__Add_validation_hash_to_content_record.sql
+++ b/src/main/resources/db/migration/V1.0.14__Add_validation_hash_to_content_record.sql
@@ -1,0 +1,37 @@
+-- =========================================================
+-- Migration: Add Validation Hash to Content Record
+-- Version: V1.0.14
+-- Author: System
+-- Date: 2026-02-19
+-- Description: Adiciona coluna validation_hash à tabela content_record
+--              para marcar conteúdo com propriedade validada.
+--              Conteúdo com hash != null possui dono reconhecido.
+-- =========================================================
+
+-- Adicionar coluna validation_hash à tabela content_record
+ALTER TABLE content_record
+ADD COLUMN validation_hash VARCHAR(512) NULL;
+
+-- Criar índice para melhorar performance de queries por hash
+CREATE INDEX idx_content_record_validation_hash ON content_record(validation_hash);
+
+-- Comentários para documentação (PostgreSQL)
+COMMENT ON COLUMN content_record.validation_hash IS 'HMAC-SHA256 hash de validação de propriedade. NULL = sem dono; != NULL = propriedade validada. Calculado com userId + contentId + channelId + secret.';
+
+-- =========================================================
+-- Notas de Implementação:
+--
+-- 1. validation_hash é NULLABLE (opcional)
+-- 2. Hash é gerado usando HMAC-SHA256 no backend
+-- 3. Conteúdo com hash NULL = sem propriedade validada
+-- 4. Conteúdo com hash preenchido = propriedade reconhecida
+-- 5. Flutter pode verificar propriedade diretamente na query
+-- 6. Evita request extra ao carregar lista de conteúdo
+-- 7. Hash máximo: 512 chars (hexadecimal de SHA256 = 64 chars + margem)
+--
+-- Fluxo de Validação:
+-- 1. Flutter envia userId + contentId para API
+-- 2. Backend valida channelId (user) == channelId (content)
+-- 3. Backend gera HMAC e atualiza content_record.validation_hash
+-- 4. Próximas queries já trazem indicador de propriedade
+-- =========================================================

--- a/src/main/resources/db/migration/V1.0.15__Create_content_ownership_table.sql
+++ b/src/main/resources/db/migration/V1.0.15__Create_content_ownership_table.sql
@@ -1,0 +1,105 @@
+-- =========================================================
+-- Migration: Create Content Ownership Table
+-- Version: V1.0.15
+-- Author: System
+-- Date: 2026-02-19
+-- Description: Cria tabela content_ownership como soft reference
+--              entre usuários e conteúdo do YouTube, com validação
+--              criptográfica HMAC-SHA256.
+-- =========================================================
+
+-- Criar ENUM para ownership_status
+CREATE TYPE ownership_status AS ENUM ('PENDING', 'VERIFIED', 'REJECTED');
+
+-- Criar tabela content_ownership
+CREATE TABLE content_ownership (
+    -- Identificação primária
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Referências (soft references - não usamos FK rígidas)
+    user_id UUID NOT NULL,
+    content_id UUID NOT NULL,
+
+    -- Campos de validação
+    youtube_channel_id VARCHAR(255) NOT NULL,
+    content_channel_id VARCHAR(255) NOT NULL,
+
+    -- Status e hash de validação
+    ownership_status ownership_status NOT NULL DEFAULT 'PENDING',
+    validation_hash VARCHAR(512) NOT NULL,
+
+    -- Auditoria de verificação
+    verified_at TIMESTAMP,
+    verified_by UUID,
+
+    -- Timestamps de auditoria
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    -- Constraint: um usuário pode validar a mesma propriedade apenas uma vez
+    CONSTRAINT uk_ownership_user_content UNIQUE (user_id, content_id)
+);
+
+-- Criar índices para performance
+CREATE INDEX idx_ownership_user_id ON content_ownership(user_id);
+CREATE INDEX idx_ownership_content_id ON content_ownership(content_id);
+CREATE INDEX idx_ownership_status ON content_ownership(ownership_status);
+CREATE INDEX idx_ownership_youtube_channel ON content_ownership(youtube_channel_id);
+CREATE INDEX idx_ownership_validation_hash ON content_ownership(validation_hash);
+CREATE INDEX idx_ownership_created_at ON content_ownership(created_at);
+
+-- Comentários para documentação (PostgreSQL)
+COMMENT ON TABLE content_ownership IS 'Tabela de soft reference entre usuários e conteúdo do YouTube. Valida propriedade através de HMAC-SHA256 sem foreign keys rígidas.';
+
+COMMENT ON COLUMN content_ownership.id IS 'Identificador único UUID da ownership.';
+COMMENT ON COLUMN content_ownership.user_id IS 'Soft reference para app_user.id. Não é FK rígida.';
+COMMENT ON COLUMN content_ownership.content_id IS 'Soft reference para content_record.id. Não é FK rígida.';
+COMMENT ON COLUMN content_ownership.youtube_channel_id IS 'YouTube Channel ID do usuário (copiado de app_user.youtube_channel_id no momento da validação).';
+COMMENT ON COLUMN content_ownership.content_channel_id IS 'YouTube Channel ID do conteúdo (copiado de content_record.channel_id no momento da validação).';
+COMMENT ON COLUMN content_ownership.ownership_status IS 'Status da ownership: PENDING (aguardando validação), VERIFIED (validada), REJECTED (hash inválido).';
+COMMENT ON COLUMN content_ownership.validation_hash IS 'HMAC-SHA256 hash calculado no backend. Garante integridade da validação.';
+COMMENT ON COLUMN content_ownership.verified_at IS 'Timestamp de quando a ownership foi verificada.';
+COMMENT ON COLUMN content_ownership.verified_by IS 'ID do administrador que verificou manualmente (opcional).';
+COMMENT ON COLUMN content_ownership.created_at IS 'Timestamp de criação do registro.';
+COMMENT ON COLUMN content_ownership.updated_at IS 'Timestamp da última atualização.';
+
+-- =========================================================
+-- Notas de Implementação:
+--
+-- 1. SOFT REFERENCES: user_id e content_id não têm FK rígidas
+--    - Dados vêm de fontes externas (YouTube API)
+--    - Ciclos de vida são independentes
+--    - Dados podem ser alterados/deletados externamente
+--
+-- 2. VALIDAÇÃO HMAC-SHA256:
+--    - Hash calculado: HMAC(userId + contentId + channelIds, secret)
+--    - Backend SEMPRE recalcula o hash (nunca confia no cliente)
+--    - Se hashes coincidirem → VERIFIED
+--    - Se hashes divergirem → REJECTED
+--
+-- 3. FLUXO DE VALIDAÇÃO:
+--    a) Flutter envia: userId, contentId, timestamp
+--    b) Backend busca: user.youtubeChannelId, content.channelId
+--    c) Backend valida: user.channelId == content.channelId
+--    d) Backend gera: HMAC-SHA256(userId + contentId + channelIds + secret)
+--    e) Backend salva: content_ownership (status VERIFIED ou REJECTED)
+--    f) Backend atualiza: content_record.validation_hash (para query rápida)
+--
+-- 4. CONSTRAINT ÚNICA:
+--    - Um usuário só pode validar ownership do mesmo conteúdo uma vez
+--    - Evita duplicatas e re-validações desnecessárias
+--
+-- 5. ÍNDICES:
+--    - user_id: lista todo conteúdo de um usuário
+--    - content_id: verifica quem reivindicou um conteúdo
+--    - status: queries por status (pending, verified, rejected)
+--    - youtube_channel_id: busca por canal
+--    - validation_hash: validação de integridade
+--    - created_at: ordem cronológica
+--
+-- 6. SEGURANÇA:
+--    - Todos os endpoints protegidos com JWT
+--    - Usuário só pode validar ownership para seu próprio userId
+--    - Secret key gerenciada via variável de ambiente
+--    - Hash sempre recalculado no backend
+-- =========================================================

--- a/src/main/resources/db/migration/V1.0.16__Add_audit_fields_to_ownership.sql
+++ b/src/main/resources/db/migration/V1.0.16__Add_audit_fields_to_ownership.sql
@@ -1,0 +1,71 @@
+-- =========================================================
+-- Migration: Add Audit Fields to Content Ownership
+-- Version: V1.0.16
+-- Author: System
+-- Date: 2026-02-19
+-- Description: Adiciona campos de auditoria para tracking de
+--              tentativas, rejeições e cancelamentos de ownership.
+--              Implementa suporte a retry e idempotência.
+-- =========================================================
+
+-- Adicionar campo rejection_reason (motivo da rejeição)
+ALTER TABLE content_ownership
+ADD COLUMN rejection_reason TEXT NULL;
+
+-- Adicionar campo retry_count (contador de tentativas)
+ALTER TABLE content_ownership
+ADD COLUMN retry_count INTEGER NOT NULL DEFAULT 0;
+
+-- Adicionar campo last_attempt_at (última tentativa)
+ALTER TABLE content_ownership
+ADD COLUMN last_attempt_at TIMESTAMP NULL;
+
+-- Adicionar campo cancelled_by_user (cancelado pelo usuário)
+ALTER TABLE content_ownership
+ADD COLUMN cancelled_by_user BOOLEAN NOT NULL DEFAULT false;
+
+-- Criar índice para queries de retry
+CREATE INDEX idx_ownership_retry_count ON content_ownership(retry_count);
+
+-- Criar índice para queries de cancelamentos
+CREATE INDEX idx_ownership_cancelled ON content_ownership(cancelled_by_user);
+
+-- Comentários para documentação (PostgreSQL)
+COMMENT ON COLUMN content_ownership.rejection_reason IS 'Motivo detalhado da rejeição: CHANNEL_MISMATCH, NO_CHANNEL, USER_CANCELLED, etc.';
+COMMENT ON COLUMN content_ownership.retry_count IS 'Número de tentativas de validação. Incrementado a cada resubmissão.';
+COMMENT ON COLUMN content_ownership.last_attempt_at IS 'Timestamp da última tentativa de validação (sucesso ou falha).';
+COMMENT ON COLUMN content_ownership.cancelled_by_user IS 'true = usuário cancelou o pedido; false = rejeição automática do sistema.';
+
+-- =========================================================
+-- Notas de Implementação:
+--
+-- 1. IDEMPOTÊNCIA:
+--    - Constraint UNIQUE (user_id, content_id) garante apenas 1 registro
+--    - Resubmissões ATUALIZAM o registro existente (não criam duplicatas)
+--    - retry_count é incrementado automaticamente no Service
+--
+-- 2. REJECTION TRACKING:
+--    - rejection_reason armazena o motivo específico da rejeição
+--    - Valores possíveis: CHANNEL_MISMATCH, NO_CHANNEL, USER_CANCELLED
+--    - NULL quando status = VERIFIED
+--
+-- 3. RETRY LOGIC:
+--    - retry_count começa em 0 na primeira tentativa
+--    - Incrementado a cada nova tentativa
+--    - Permite implementar limite de retries no futuro
+--
+-- 4. USER CANCELLATION:
+--    - cancelled_by_user = true → usuário explicitamente cancelou
+--    - cancelled_by_user = false → sistema rejeitou automaticamente
+--    - Útil para analytics e suporte ao cliente
+--
+-- 5. TIMESTAMP TRACKING:
+--    - last_attempt_at registra TODAS as tentativas (sucesso ou falha)
+--    - updated_at continua registrando qualquer mudança no registro
+--    - created_at permanece inalterado (primeira tentativa)
+--
+-- 6. FUTURO - AUDIT LOG TABLE:
+--    - Estes campos são suficientes para auditoria básica
+--    - Se precisar histórico COMPLETO, criar ownership_audit_log depois
+--    - Por ora, mantemos simplicidade com campos diretos
+-- =========================================================

--- a/src/main/resources/db/migration/V1.0.17__Convert_ownership_status_to_varchar.sql
+++ b/src/main/resources/db/migration/V1.0.17__Convert_ownership_status_to_varchar.sql
@@ -1,0 +1,35 @@
+-- =========================================================
+-- Migration: Convert ownership_status from ENUM to VARCHAR
+-- Version: V1.0.17
+-- Author: System
+-- Date: 2026-02-19
+-- Description: Converte coluna ownership_status de tipo ENUM customizado
+--              para VARCHAR para compatibilidade com Hibernate/JPA
+-- =========================================================
+
+-- Passo 1: Remover o DEFAULT (que depende do tipo ENUM)
+ALTER TABLE content_ownership
+    ALTER COLUMN ownership_status DROP DEFAULT;
+
+-- Passo 2: Alterar coluna para VARCHAR usando CAST
+ALTER TABLE content_ownership
+    ALTER COLUMN ownership_status TYPE VARCHAR(20)
+    USING ownership_status::VARCHAR;
+
+-- Passo 3: Restaurar DEFAULT como VARCHAR
+ALTER TABLE content_ownership
+    ALTER COLUMN ownership_status SET DEFAULT 'PENDING';
+
+-- Passo 4: Adicionar constraint de validação (garante apenas valores válidos)
+ALTER TABLE content_ownership
+    ADD CONSTRAINT chk_ownership_status
+    CHECK (ownership_status IN ('PENDING', 'VERIFIED', 'REJECTED'));
+
+-- Passo 5: Agora podemos dropar o tipo ENUM (não há mais dependências)
+DROP TYPE IF EXISTS ownership_status;
+
+-- =========================================================
+-- Notas:
+-- - VARCHAR(20) é suficiente para 'PENDING', 'VERIFIED', 'REJECTED'
+-- - CHECK constraint garante apenas valores válidos
+-- - DEFAULT foi replicado como VARCHAR

--- a/src/test/java/br/com/aguideptbr/features/ownership/ContentOwnershipServiceTest.java
+++ b/src/test/java/br/com/aguideptbr/features/ownership/ContentOwnershipServiceTest.java
@@ -1,0 +1,399 @@
+package br.com.aguideptbr.features.ownership;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import br.com.aguideptbr.features.content.ContentRecordModel;
+import br.com.aguideptbr.features.content.ContentType;
+import br.com.aguideptbr.features.ownership.dto.OwnershipStatusResponse;
+import br.com.aguideptbr.features.ownership.dto.UserContentResponse;
+import br.com.aguideptbr.features.ownership.dto.ValidateOwnershipRequest;
+import br.com.aguideptbr.features.ownership.dto.ValidateOwnershipResponse;
+import br.com.aguideptbr.features.user.UserModel;
+import br.com.aguideptbr.features.user.UserRole;
+import io.quarkus.test.junit.QuarkusTest;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
+
+/**
+ * Integration tests for ContentOwnershipService.
+ *
+ * Tests the complete ownership validation flow:
+ * - HMAC-SHA256 hash calculation
+ * - Channel ID matching validation
+ * - Ownership record creation
+ * - Content hash update
+ */
+@QuarkusTest
+class ContentOwnershipServiceTest {
+
+    @Inject
+    ContentOwnershipService ownershipService;
+
+    private UserModel testUser;
+    private ContentRecordModel testContent;
+    private static final String TEST_CHANNEL_ID = "UCTestChannel123456789";
+
+    @BeforeEach
+    @Transactional
+    void setup() {
+        // Clean up previous test data
+        ContentOwnershipModel.deleteAll();
+
+        // Create test user with YouTube channel
+        testUser = new UserModel();
+        testUser.name = "Test";
+        testUser.surname = "Owner";
+        testUser.email = "test.owner." + System.currentTimeMillis() + "@test.com";
+        testUser.passwordHash = "test-hash";
+        testUser.role = UserRole.FREE;
+        testUser.youtubeChannelId = TEST_CHANNEL_ID;
+        testUser.persist();
+
+        // Create test content with matching channel ID
+        testContent = new ContentRecordModel();
+        testContent.title = "Test Video " + System.currentTimeMillis();
+        testContent.videoUrl = "https://test.com/video/" + System.currentTimeMillis();
+        testContent.channelId = TEST_CHANNEL_ID; // Matches user's channel
+        testContent.channelName = "Test Channel";
+        testContent.type = ContentType.VIDEO;
+        testContent.persist();
+    }
+
+    @Test
+    @Transactional
+    void testValidateOwnership_Success() {
+        // Arrange
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                testContent.id);
+
+        // Act
+        ValidateOwnershipResponse response = ownershipService.validateOwnership(request);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(OwnershipStatus.VERIFIED, response.getStatus());
+        assertNotNull(response.getOwnershipId());
+        assertEquals(testUser.id, response.getUserId());
+        assertEquals(testContent.id, response.getContentId());
+        assertEquals(TEST_CHANNEL_ID, response.getYoutubeChannelId());
+        assertEquals(TEST_CHANNEL_ID, response.getContentChannelId());
+        assertNotNull(response.getValidationHash());
+        assertNotNull(response.getVerifiedAt());
+
+        // Verify content hash was updated
+        ContentRecordModel updatedContent = ContentRecordModel.findById(testContent.id);
+        assertNotNull(updatedContent.validationHash);
+        assertEquals(response.getValidationHash(), updatedContent.validationHash);
+    }
+
+    @Test
+    @Transactional
+    void testValidateOwnership_ChannelMismatch() {
+        // Arrange - Content with different channel ID
+        ContentRecordModel differentContent = new ContentRecordModel();
+        differentContent.title = "Different Channel Video";
+        differentContent.videoUrl = "https://test.com/different/" + System.currentTimeMillis();
+        differentContent.channelId = "UCDifferentChannel987654321";
+        differentContent.channelName = "Different Channel";
+        differentContent.type = ContentType.VIDEO;
+        differentContent.persist();
+
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                differentContent.id);
+
+        // Act
+        ValidateOwnershipResponse response = ownershipService.validateOwnership(request);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(OwnershipStatus.REJECTED, response.getStatus());
+        assertTrue(response.getMessage().contains("Channel IDs do not match"));
+
+        // Verify content hash was NOT updated
+        ContentRecordModel updatedContent = ContentRecordModel.findById(differentContent.id);
+        assertNull(updatedContent.validationHash);
+    }
+
+    @Test
+    @Transactional
+    void testValidateOwnership_UserWithoutChannel() {
+        // Arrange - User without YouTube channel ID
+        UserModel userWithoutChannel = new UserModel();
+        userWithoutChannel.name = "No";
+        userWithoutChannel.surname = "Channel";
+        userWithoutChannel.email = "no.channel." + System.currentTimeMillis() + "@test.com";
+        userWithoutChannel.passwordHash = "test-hash";
+        userWithoutChannel.role = UserRole.FREE;
+        userWithoutChannel.youtubeChannelId = null; // No channel
+        userWithoutChannel.persist();
+
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                userWithoutChannel.id,
+                testContent.id);
+
+        // Act
+        ValidateOwnershipResponse response = ownershipService.validateOwnership(request);
+
+        // Assert
+        assertNotNull(response);
+        assertEquals(OwnershipStatus.REJECTED, response.getStatus());
+        assertTrue(response.getMessage().contains("has no YouTube channel ID"));
+    }
+
+    @Test
+    @Transactional
+    void testGetOwnershipStatus() {
+        // Arrange - Create verified ownership
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                testContent.id);
+        ownershipService.validateOwnership(request);
+
+        // Act
+        OwnershipStatusResponse status = ownershipService.getOwnershipStatus(
+                testUser.id,
+                testContent.id);
+
+        // Assert
+        assertNotNull(status);
+        assertEquals(OwnershipStatus.VERIFIED, status.getStatus());
+        assertTrue(status.isVerified());
+        assertTrue(status.isChannelsMatch());
+        assertNotNull(status.getVerifiedAt());
+    }
+
+    @Test
+    @Transactional
+    void testGetUserVerifiedContent() {
+        // Arrange - Create multiple verified contents
+        ValidateOwnershipRequest request1 = new ValidateOwnershipRequest(
+                testUser.id,
+                testContent.id);
+        ownershipService.validateOwnership(request1);
+
+        ContentRecordModel content2 = new ContentRecordModel();
+        content2.title = "Second Video";
+        content2.videoUrl = "https://test.com/video2/" + System.currentTimeMillis();
+        content2.channelId = TEST_CHANNEL_ID;
+        content2.channelName = "Test Channel";
+        content2.type = ContentType.VIDEO;
+        content2.persist();
+
+        ValidateOwnershipRequest request2 = new ValidateOwnershipRequest(
+                testUser.id,
+                content2.id);
+        ownershipService.validateOwnership(request2);
+
+        // Act
+        List<UserContentResponse> verifiedContent = ownershipService.getUserVerifiedContent(
+                testUser.id);
+
+        // Assert
+        assertNotNull(verifiedContent);
+        assertEquals(2, verifiedContent.size());
+
+        UserContentResponse first = verifiedContent.get(0);
+        assertTrue(first.isVerified());
+        assertNotNull(first.getValidationHash());
+        assertNotNull(first.getVerifiedAt());
+    }
+
+    @Test
+    @Transactional
+    void testOwnershipModel_FindMethods() {
+        // Arrange
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                testContent.id);
+        ownershipService.validateOwnership(request);
+
+        // Act & Assert - Test static finder methods
+        List<ContentOwnershipModel> userOwnerships = ContentOwnershipModel
+                .findByUserId(testUser.id);
+        assertEquals(1, userOwnerships.size());
+
+        List<ContentOwnershipModel> verifiedOwnerships = ContentOwnershipModel
+                .findVerifiedByUserId(testUser.id);
+        assertEquals(1, verifiedOwnerships.size());
+
+        ContentOwnershipModel ownership = ContentOwnershipModel
+                .findByUserAndContent(testUser.id, testContent.id);
+        assertNotNull(ownership);
+        assertEquals(OwnershipStatus.VERIFIED, ownership.ownershipStatus);
+
+        assertTrue(ContentOwnershipModel.ownershipExists(testUser.id, testContent.id));
+        assertTrue(ContentOwnershipModel.isVerified(testUser.id, testContent.id));
+    }
+
+    @Test
+    @Transactional
+    void testIdempotency_RetryIncrements() {
+        // Arrange - Content with different channel (will be REJECTED)
+        ContentRecordModel differentContent = new ContentRecordModel();
+        differentContent.title = "Wrong Channel Video";
+        differentContent.videoUrl = "https://test.com/wrong/" + System.currentTimeMillis();
+        differentContent.channelId = "UCWrongChannel999";
+        differentContent.channelName = "Wrong Channel";
+        differentContent.type = ContentType.VIDEO;
+        differentContent.persist();
+
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                differentContent.id);
+
+        // Act - First attempt (REJECTED)
+        ValidateOwnershipResponse response1 = ownershipService.validateOwnership(request);
+        assertEquals(OwnershipStatus.REJECTED, response1.getStatus());
+
+        ContentOwnershipModel ownership1 = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                differentContent.id);
+        assertEquals(0, ownership1.retryCount); // First attempt
+        assertEquals("CHANNEL_MISMATCH", ownership1.rejectionReason);
+        assertNotNull(ownership1.lastAttemptAt);
+
+        // Act - Second attempt (still REJECTED)
+        ValidateOwnershipResponse response2 = ownershipService.validateOwnership(request);
+        assertEquals(OwnershipStatus.REJECTED, response2.getStatus());
+
+        ContentOwnershipModel ownership2 = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                differentContent.id);
+        assertEquals(1, ownership2.retryCount); // Incremented
+        assertEquals("CHANNEL_MISMATCH", ownership2.rejectionReason);
+
+        // Act - Third attempt (still REJECTED)
+        ownershipService.validateOwnership(request);
+
+        ContentOwnershipModel ownership3 = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                differentContent.id);
+        assertEquals(2, ownership3.retryCount); // Incremented again
+    }
+
+    @Test
+    @Transactional
+    void testIdempotency_SuccessAfterRejection() {
+        // Arrange - Create content initially with wrong channel
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                testContent.id);
+
+        // Act - First: Reject by unsetting user's channel
+        UserModel user = UserModel.findById(testUser.id);
+        user.youtubeChannelId = null;
+        // No need to call persist() - Hibernate tracks changes automatically
+
+        ValidateOwnershipResponse rejection = ownershipService.validateOwnership(request);
+        assertEquals(OwnershipStatus.REJECTED, rejection.getStatus());
+
+        ContentOwnershipModel ownershipRejected = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                testContent.id);
+        assertEquals("NO_CHANNEL", ownershipRejected.rejectionReason);
+        assertEquals(0, ownershipRejected.retryCount);
+
+        // Act - Second: Fix user's channel and retry
+        user = UserModel.findById(testUser.id);
+        user.youtubeChannelId = TEST_CHANNEL_ID;
+        // No need to call persist() - Hibernate tracks changes automatically
+
+        ValidateOwnershipResponse success = ownershipService.validateOwnership(request);
+        assertEquals(OwnershipStatus.VERIFIED, success.getStatus());
+
+        ContentOwnershipModel ownershipVerified = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                testContent.id);
+        assertNull(ownershipVerified.rejectionReason); // Cleared on success
+        assertEquals(1, ownershipVerified.retryCount); // Incremented
+        assertNotNull(ownershipVerified.verifiedAt);
+    }
+
+    @Test
+    @Transactional
+    void testCancelOwnership() {
+        // Arrange - Create ownership first
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                testContent.id);
+        ownershipService.validateOwnership(request);
+
+        ContentOwnershipModel ownershipBefore = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                testContent.id);
+        assertEquals(OwnershipStatus.VERIFIED, ownershipBefore.ownershipStatus);
+
+        // Act - Cancel ownership
+        ValidateOwnershipResponse cancelResponse = ownershipService.cancelOwnershipClaim(
+                testUser.id,
+                testContent.id);
+
+        // Assert
+        assertEquals(OwnershipStatus.REJECTED, cancelResponse.getStatus());
+        assertTrue(cancelResponse.getMessage().contains("cancelled by user"));
+
+        ContentOwnershipModel ownershipAfter = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                testContent.id);
+        assertEquals(OwnershipStatus.REJECTED, ownershipAfter.ownershipStatus);
+        assertEquals("USER_CANCELLED", ownershipAfter.rejectionReason);
+        assertTrue(ownershipAfter.cancelledByUser);
+        assertNotNull(ownershipAfter.lastAttemptAt);
+    }
+
+    @Test
+    @Transactional
+    void testRejectionReason_NoChannel() {
+        // Arrange - Re-fetch user and remove channel
+        UserModel user = UserModel.findById(testUser.id);
+        user.youtubeChannelId = null;
+        // No need to call persist() - Hibernate tracks changes automatically
+
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                testContent.id);
+
+        // Act
+        ownershipService.validateOwnership(request);
+
+        // Assert
+        ContentOwnershipModel ownership = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                testContent.id);
+        assertEquals(OwnershipStatus.REJECTED, ownership.ownershipStatus);
+        assertEquals("NO_CHANNEL", ownership.rejectionReason);
+    }
+
+    @Test
+    @Transactional
+    void testRejectionReason_ChannelMismatch() {
+        // Arrange - Re-fetch content and update channel
+        ContentRecordModel content = ContentRecordModel.findById(testContent.id);
+        content.channelId = "UCDifferentChannel123";
+        // No need to call persist() - Hibernate tracks changes automatically
+
+        ValidateOwnershipRequest request = new ValidateOwnershipRequest(
+                testUser.id,
+                testContent.id);
+
+        // Act
+        ownershipService.validateOwnership(request);
+
+        // Assert
+        ContentOwnershipModel ownership = ContentOwnershipModel.findByUserAndContent(
+                testUser.id,
+                testContent.id);
+        assertEquals(OwnershipStatus.REJECTED, ownership.ownershipStatus);
+        assertEquals("CHANNEL_MISMATCH", ownership.rejectionReason);
+    }
+}


### PR DESCRIPTION
- Added OwnershipStatus enum to represent the status of content ownership validation.
- Created OwnershipStatusResponse DTO for querying the current ownership status of specific content.
- Developed UserContentResponse DTO to include content details and ownership information.
- Introduced ValidateOwnershipRequest DTO for content ownership validation requests.
- Implemented ValidateOwnershipResponse DTO for responses after validating ownership claims.
- Added SQL migration scripts to create content_ownership table and add validation_hash to content_record.
- Enhanced content ownership model with audit fields for tracking attempts, rejections, and cancellations.
- Converted ownership_status from ENUM to VARCHAR for compatibility with Hibernate/JPA.
- Developed comprehensive integration tests for ContentOwnershipService, covering validation flow, rejection reasons, and idempotency.